### PR TITLE
Do not sync figs, only push them, since they should not be edited on Overleaf

### DIFF
--- a/calkit.yaml
+++ b/calkit.yaml
@@ -23,7 +23,6 @@ publications:
         - references.bib
         - numbers.tex
         - elsarticle-num-names.bst
-        - figs/
       push_paths:
         - figs
       last_sync_commit: 264eb217e8ec924d8d6324ef5d0ff86499e86829


### PR DESCRIPTION
As the rest of the pipeline is filled out, `figs` should be generated/saved in the main repo and changes should be pushed to Overleaf, i.e., Overleaf is only a platform for collaborating on the text with team members who don't want to use Git/GitHub.