### PR TITLE
Remove OpenFLASH submodule configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "mdocean/simulation/modules/OpenFLASH"]
-	path = mdocean/simulation/modules/OpenFLASH
-	url = https://github.com/symbiotic-engineering/OpenFLASH.git
 [submodule "mdocean/SAFE"]
 	path = mdocean/SAFE
 	url = https://github.com/rebeccamccabe/SAFE-matlab.git


### PR DESCRIPTION
Removed OpenFLASH submodule from .gitmodules because the nested submodule sea-lab-utils causes intermittent CI errors.