### PR TITLE
Relock wec-sim from mip-org/core

### DIFF
--- a/mip.lock
+++ b/mip.lock
@@ -1,7 +1,7 @@
 {
   "lock_version": 1,
   "mip_version": "mep-0009",
-  "spec_sha256": "717a0ce73e1d3c7264c01ee2ae58e88d48559d8e46d79e090d2774ab9e987307",
+  "spec_sha256": "665628a1fcd38cfb10396b2c55238a1f99cc582341975158a787d8681c5b34ea",
   "packages": [
     {
       "fqn": "gh/mip-org/labs/openflash",
@@ -18,12 +18,12 @@
       "groups": []
     },
     {
-      "fqn": "gh/mip-org/staging/wec-sim",
+      "fqn": "gh/mip-org/core/wec-sim",
       "name": "wec-sim",
       "version": "7.1.0",
       "architecture": "any",
-      "mhl_url": "https://github.com/mip-org/mip-staging/releases/download/wec_sim-7.1.0/wec_sim-7.1.0-any.mhl",
-      "mhl_sha256": "d9a6ca29867b3a1a8909c5580e080fb2272a6bab273c4f1db5fe4f5c28c1c4fa",
+      "mhl_url": "https://github.com/mip-org/mip-core/releases/download/wec_sim-7.1.0/wec_sim-7.1.0-any.mhl",
+      "mhl_sha256": "78cd5af524a5c4afa03f4a3e154349978d5c0c0164b91c9c058429f5168e5fd4",
       "commit_hash": "a23d2993807410fe78cc63546c1ba9d81912024f",
       "source_hash": "1e498f47bd194d6c721dc57f11d8609d653b3db4",
       "dependencies": [],

--- a/mip.yaml
+++ b/mip.yaml
@@ -25,5 +25,5 @@ dependency_groups:
 
 channels:
   # Consulted after mip-org/core when resolving the bare names above.
-  - mip-org/staging # wec-sim, safe
+  - mip-org/staging # safe
   - mip-org/labs # openflash


### PR DESCRIPTION
Fixes the 404 in https://github.com/symbiotic-engineering/MDOcean/pull/305#issuecomment-5186143494.

`wec-sim@7.1.0` was promoted from `mip-org/staging` to `mip-org/core` on 2026-07-28, and mip-staging's prune-promoted job then retracted the staging copy — package folder removed and the GitHub Release deleted (mip-org/mip-staging@f6bf0a5). Staging only advertises what is pending or in progress, so the release URL pinned in `mip.lock` no longer exists.

`mip.yaml` already declares a bare `wec-sim` and core is consulted first, so `mip project lock` moves it to `gh/mip-org/core/wec-sim`. `commit_hash` and `source_hash` are unchanged — same package, new home. The `mip.yaml` change drops the now-stale `wec-sim` from the staging channel annotation (which is why `spec_sha256` changes too).

Verified with a clean `mip project sync --yes`: all three packages install and `mip project status` reports `status: ok`.